### PR TITLE
Use java8 and open docker after install to create symlinks

### DIFF
--- a/bin/wasabi.sh
+++ b/bin/wasabi.sh
@@ -16,8 +16,8 @@
 ###############################################################################
 
 formulas=("bash" "cask" "git" "git-flow-avh" "maven" "wget" "ruby" "node")
-taps=("caskroom/cask")
-casks=("java" "docker")
+taps=("caskroom/cask" "caskroom/versions")
+casks=("java8" "docker")
 profile_default=development
 endpoint_default=localhost:8080
 verify_default=false
@@ -115,6 +115,8 @@ bootstrap() {
       [[ $(brew cask list ${cask} 2>/dev/null) ]] && brew cask uninstall --force ${cask} 2>/dev/null
       brew cask install --force ${cask}
     done
+
+    open /Applications/Docker.app
 
     npm config set prefix $(brew --prefix)
 


### PR DESCRIPTION
- Wasabi seems to specifically require java 8, and fails to build with other versions
- When I ran the bootstrap script it broke my existing install of docker by removing the CLI tool. [The internet](https://stackoverflow.com/questions/40523307/brew-install-docker-does-not-include-docker-engine/43365425#43365425) suggests that that's because the symlinks that let you run `docker` on the command line don't get set up until you open the docker app, so instead of requiring people to install docker manually like I did, we'll try just opening it after install